### PR TITLE
Add integration with Datadog

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,94 @@
+require:
+  - rubocop-rspec
+  - rubocop-performance
+inherit_gem:
+    rubocop-shopify: rubocop.yml
+
+AllCops:
+  NewCops: disable
+  UseCache: true
+  TargetRubyVersion: 2.7.2
+
+Bundler/OrderedGems:
+  Enabled: false
+
+Layout/BlockAlignment:
+  EnforcedStyleAlignWith: start_of_block
+
+Layout/FirstArrayElementIndentation:
+  EnforcedStyle: consistent
+
+Layout/FirstHashElementIndentation:
+  EnforcedStyle: consistent
+
+Layout/EmptyLinesAroundModuleBody:
+  EnforcedStyle: empty_lines_except_namespace
+
+Layout/EmptyLinesAroundClassBody:
+  EnforcedStyle: empty_lines
+
+Layout/EndAlignment:
+  AutoCorrect: true
+
+Style/AsciiComments:
+  Enabled: false
+
+Style/MultilineBlockChain:
+  Enabled: false
+
+Style/OptionalBooleanParameter:
+  Enabled: false
+
+Style/TrailingCommaInArguments:
+  EnforcedStyleForMultiline: comma
+
+Style/TrailingCommaInHashLiteral:
+  EnforcedStyleForMultiline: comma
+
+Style/TrailingCommaInArrayLiteral:
+  EnforcedStyleForMultiline: comma
+
+Style/SymbolProc:
+  IgnoredMethods:
+    - respond_to
+    - define_method
+    - node
+    - code
+
+Style/RaiseArgs:
+  EnforcedStyle: compact
+
+Style/PreferredHashMethods:
+  EnforcedStyle: verbose
+
+Style/SymbolArray:
+  EnforcedStyle: brackets
+
+Style/FormatStringToken:
+  Enabled: false
+
+Style/FormatString:
+  Enabled: false
+
+Naming/VariableNumber:
+  EnforcedStyle: snake_case
+  CheckMethodNames: false
+  CheckSymbols: false
+
+RSpec/MessageSpies:
+  EnforcedStyle: have_received
+
+RSpec/ExampleLength:
+  Enabled: false
+
+RSpec/MultipleExpectations:
+  Enabled: false
+
+RSpec/PredicateMatcher:
+  Enabled: false
+
+Style/LambdaCall:
+  Enabled: false
+
+Metrics/ParameterLists:
+  Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,5 @@
-source "https://rubygems.org"
+# frozen_string_literal: true
+source 'https://rubygems.org'
 
 # Specify your gem's dependencies in hivelog.gemspec
 gemspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,6 +7,9 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
+    ast (2.4.2)
+    ddtrace (0.45.0)
+      msgpack
     diff-lcs (1.3)
     elasticsearch (7.3.0)
       elasticsearch-api (= 7.3.0)
@@ -18,9 +21,16 @@ GEM
       multi_json
     faraday (0.15.4)
       multipart-post (>= 1.2, < 3)
+    msgpack (1.4.2)
     multi_json (1.13.1)
     multipart-post (2.1.1)
+    parallel (1.20.1)
+    parser (3.0.0.0)
+      ast (~> 2.4.1)
+    rainbow (3.0.0)
     rake (13.0.1)
+    regexp_parser (2.0.3)
+    rexml (3.2.4)
     rspec (3.8.0)
       rspec-core (~> 3.8.0)
       rspec-expectations (~> 3.8.0)
@@ -34,15 +44,37 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.8.0)
     rspec-support (3.8.2)
+    rubocop (1.9.1)
+      parallel (~> 1.10)
+      parser (>= 3.0.0.0)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 1.8, < 3.0)
+      rexml
+      rubocop-ast (>= 1.2.0, < 2.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 1.4.0, < 3.0)
+    rubocop-ast (1.4.1)
+      parser (>= 2.7.1.5)
+    rubocop-rspec (2.1.0)
+      rubocop (~> 1.0)
+      rubocop-ast (>= 1.1.0)
+    rubocop-shopify (1.0.7)
+      rubocop (~> 1.4)
+    ruby-progressbar (1.11.0)
+    unicode-display_width (2.0.0)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
   bundler (~> 2.0)
+  ddtrace (~> 0.45)
   hivelog!
   rake (~> 13.0)
   rspec (~> 3.0)
+  rubocop (~> 1.9)
+  rubocop-rspec (~> 2.1)
+  rubocop-shopify (~> 1.0)
 
 BUNDLED WITH
-   2.0.1
+   2.1.4

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,7 @@
-require "bundler/gem_tasks"
-require "rspec/core/rake_task"
+# frozen_string_literal: true
+require 'bundler/gem_tasks'
+require 'rspec/core/rake_task'
 
 RSpec::Core::RakeTask.new(:spec)
 
-task :default => :spec
+task default: :spec

--- a/bin/console
+++ b/bin/console
@@ -1,7 +1,8 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
-require "bundler/setup"
-require "hivelog"
+require 'bundler/setup'
+require 'hivelog'
 
 # You can add fixtures and/or initialization code here to make experimenting
 # with your gem easier. You can also use a different console, if you like.
@@ -10,5 +11,5 @@ require "hivelog"
 # require "pry"
 # Pry.start
 
-require "irb"
+require 'irb'
 IRB.start(__FILE__)

--- a/hivelog.gemspec
+++ b/hivelog.gemspec
@@ -1,39 +1,43 @@
-
-lib = File.expand_path("../lib", __FILE__)
+# frozen_string_literal: true
+lib = File.expand_path('lib', __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require "hivelog/version"
+require 'hivelog/version'
 
 Gem::Specification.new do |spec|
-  spec.name          = "hivelog"
+  spec.name          = 'hivelog'
   spec.version       = Hivelog::VERSION
-  spec.authors       = ["Tian JIANG"]
-  spec.email         = ["tian@hivebrite.com"]
+  spec.authors       = ['Tian JIANG']
+  spec.email         = ['tian@hivebrite.com']
 
-  spec.summary       = %q{Hivebrite log client}
-  spec.description   = %q{Hivebrite log client}
-  spec.homepage      = "https://hivebrite.com"
-  spec.license       = "MIT"
+  spec.summary       = 'Hivebrite log client'
+  spec.description   = 'Hivebrite log client'
+  spec.homepage      = 'https://hivebrite.com'
+  spec.license       = 'MIT'
 
   # Prevent pushing this gem to RubyGems.org. To allow pushes either set the 'allowed_push_host'
   # to allow pushing to a single host or delete this section to allow pushing to any host.
   if spec.respond_to?(:metadata)
-    spec.metadata["homepage_uri"] = spec.homepage
+    spec.metadata['homepage_uri'] = spec.homepage
   else
-    raise "RubyGems 2.0 or newer is required to protect against " \
-      "public gem pushes."
+    raise 'RubyGems 2.0 or newer is required to protect against ' \
+      'public gem pushes.'
   end
 
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.
-  spec.files         = Dir.chdir(File.expand_path('..', __FILE__)) do
-    `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
+  spec.files = Dir.chdir(File.expand_path(__dir__)) do
+    %x(git ls-files -z).split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   end
-  spec.bindir        = "exe"
+  spec.bindir        = 'exe'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
-  spec.require_paths = ["lib"]
+  spec.require_paths = ['lib']
 
-  spec.add_development_dependency "bundler", "~> 2.0"
-  spec.add_development_dependency "rake", "~> 13.0"
-  spec.add_development_dependency "rspec", "~> 3.0"
-  spec.add_dependency "elasticsearch", "~> 7.3"
+  spec.add_development_dependency('bundler', '~> 2.0')
+  spec.add_development_dependency('ddtrace', '~> 0.45')
+  spec.add_development_dependency('rake', '~> 13.0')
+  spec.add_development_dependency('rspec', '~> 3.0')
+  spec.add_development_dependency('rubocop', '~> 1.9')
+  spec.add_development_dependency('rubocop-shopify', '~> 1.0')
+  spec.add_development_dependency('rubocop-rspec', '~> 2.1')
+  spec.add_dependency('elasticsearch', '~> 7.3')
 end

--- a/lib/hivelog.rb
+++ b/lib/hivelog.rb
@@ -1,2 +1,4 @@
-require "hivelog/version"
-require "hivelog/logger"
+# frozen_string_literal: true
+require 'hivelog/logger'
+require 'hivelog/datadog_logger'
+require 'hivelog/version'

--- a/lib/hivelog/datadog_logger.rb
+++ b/lib/hivelog/datadog_logger.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+require 'ddtrace'
+
+module Hivelog
+  class DatadogLogger < Logger
+
+    def datadog_body
+      correlation = Datadog.tracer.active_correlation
+
+      {
+        dd: {
+          trace_id: correlation.trace_id.to_s,
+          span_id: correlation.span_id.to_s,
+          env: correlation.env.to_s,
+          service: correlation.service.to_s,
+          version: correlation.version.to_s,
+        },
+        ddsource: ['ruby'],
+      }
+    end
+
+    def build_payload(level, message, options = {})
+      payload = super(level, message, options)
+
+      payload.merge(datadog_body)
+    end
+
+  end
+end

--- a/lib/hivelog/logger.rb
+++ b/lib/hivelog/logger.rb
@@ -1,13 +1,15 @@
+# frozen_string_literal: true
 require 'elasticsearch'
 require 'time'
 require 'json'
 
 module Hivelog
   class Logger
+
     attr_accessor :client, :labels, :output, :min_level
 
-    LOG_LEVELS = [:debug, :info, :warn, :error, :fatal, :panic]
-    OUTPUT = [:stdout, :elasticsearch]
+    LOG_LEVELS = [:debug, :info, :warn, :error, :fatal, :panic].freeze
+    OUTPUT = [:stdout, :elasticsearch].freeze
     LOG_LEVELS.each do |level|
       define_method level do |*message_arg|
         create_message(level, message_arg[0], message_arg[1])
@@ -17,29 +19,29 @@ module Hivelog
     def initialize(op, min_level, labels = {}, url = nil)
       @min_level = min_level
       @output = op
-      if OUTPUT.include?(output) && output == :elasticsearch
-        @client = Elasticsearch::Client.new host: url
-      end
+      @client = Elasticsearch::Client.new(host: url) if OUTPUT.include?(output) && output == :elasticsearch
       @labels = labels
     end
-    
+
     def create_message(level, message, options = {})
       return if LOG_LEVELS.index(@min_level) > LOG_LEVELS.index(level)
+
       payload = build_payload(level, message, options.to_h)
+
       if @output == :elasticsearch
-        @client.index index: generate_index(payload[:"@timestamp"]), body: payload
+        @client.index(index: generate_index(payload[:"@timestamp"]), body: payload)
       elsif @output == :stdout
         STDOUT.print(payload.to_json + "\n")
       end
     end
 
     def build_payload(level, message, options = {})
-      payload = {
+      {
         labels: @labels,
         level: level,
         message: message,
         "@timestamp": Time.now.utc,
-        ecs: { version: Hivelog::ECS_VERSION }
+        ecs: { version: Hivelog::ECS_VERSION },
       }.merge(options)
     end
 
@@ -47,5 +49,6 @@ module Hivelog
       t = event_time.utc
       "hivelog-#{t.year}.#{t.month}.#{t.day}"
     end
+
   end
 end

--- a/lib/hivelog/version.rb
+++ b/lib/hivelog/version.rb
@@ -1,4 +1,7 @@
+# frozen_string_literal: true
 module Hivelog
-  VERSION = "0.1.0"
-  ECS_VERSION = "1.4.0"
+
+  VERSION = '0.1.0'
+  ECS_VERSION = '1.4.0'
+
 end

--- a/spec/hivelog_spec.rb
+++ b/spec/hivelog_spec.rb
@@ -1,5 +1,6 @@
-RSpec.describe Hivelog do
-  it "has a version number" do
-    expect(Hivelog::VERSION).not_to be nil
+# frozen_string_literal: true
+RSpec.describe(Hivelog) do
+  it 'has a version number' do
+    expect(Hivelog::VERSION).not_to(be(nil))
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,14 +1,15 @@
-require "bundler/setup"
-require "hivelog"
+# frozen_string_literal: true
+require 'bundler/setup'
+require 'hivelog'
 
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure
-  config.example_status_persistence_file_path = ".rspec_status"
+  config.example_status_persistence_file_path = '.rspec_status'
 
   # Disable RSpec exposing methods globally on `Module` and `main`
   config.disable_monkey_patching!
 
-  config.expect_with :rspec do |c|
+  config.expect_with(:rspec) do |c|
     c.syntax = :expect
   end
 end


### PR DESCRIPTION
Add a DatadogLogger class which automatically adds Datadog expected parameter for unified tracing and logging.

To be used : 

Hivelogger::DatadogLogger.new(..) instead of Hivelogger::Logger.new(..)
it doesn't modify the initial Logger so it is possible to use different Hivelogger in the same application based on the requirements.

This permit : 
- to automically add datadog parameters
- instead of adding it manually for each calls to log anything.
- throughout all projects using datadog and hivelog.


Also: add rubocop.